### PR TITLE
IE8 fixes (for...in to forEach, submit loop)

### DIFF
--- a/source/javascripts/form-validator.js
+++ b/source/javascripts/form-validator.js
@@ -23,6 +23,7 @@
     this.parentInvalidClass = options.parentInvalidClass || 'is-errored';
     this.invalidClass = options.invalidClass || 'is-invalid';
     this.formIsValid = null;
+    this.formIsSubmitted = false;
     this.handleFieldBlur = $.proxy(this.handleFieldBlur, this);
     this.handleFormSubmit = $.proxy(this.handleFormSubmit, this);
     this.validateOnBlur = options.validateOnBlur || true;
@@ -55,10 +56,16 @@
     }
   };
 
-  FormValidator.prototype.handleFormSubmit = function() {
-    this.eventType = 'submit';
-    this.checkForm();
-    return false;
+  FormValidator.prototype.handleFormSubmit = function(event) {
+    if(this.formIsSubmitted !== true) {
+      this.eventType = 'submit';
+      this.checkForm();
+      return false;
+    }
+    else {
+      return true;
+    }
+
   };
 
   FormValidator.prototype.setupEventHandlers = function() {
@@ -69,6 +76,7 @@
 
   FormValidator.prototype.checkForm = function(e) {
     if(this.checkAllFields()) {
+      this.formIsSubmitted = true;
       this.$form.submit();
     }
     else {

--- a/source/javascripts/form-validator.js
+++ b/source/javascripts/form-validator.js
@@ -83,10 +83,11 @@
     this.formIsValid = true;
     this.summaryIsVisible = true;
 
-    for(field in this.requiredFields) {
-      that.setCurrentField(this.requiredFields[field].elem);
-      that.checkValidity(this.requiredFields[field]);
-    }
+    this.requiredFields.forEach(function(field) {
+      that.setCurrentField(field.elem);
+      that.checkValidity(field);
+    });
+
     this.updateSummary();
 
     return this.formIsValid;
@@ -271,11 +272,13 @@
     var field;
     var $items = [];
     var invalidFields = this.getInvalidFields();
+    var that = this;
 
     this.$errorList.empty();
-    for(field in invalidFields) {
-      $items.push(this.createSummaryItem(invalidFields[field].elem));
-    }
+    invalidFields.forEach(function(field) {
+      $items.push(that.createSummaryItem(field.elem));
+    });
+
     this.$errorList.append($items);
   };
 


### PR DESCRIPTION
Testing form-validator.js within IE8 I came up against two browser quirks.

IE8 doesn't have `Array#filter`, so I added es5-shim. The for...in loops then iterated over the added properties of Array because there wasn't a hasOwnProperty check in the loop. Rather than add one, I've switched to use `Array#forEach` (since you're using es5 features anyway).

IE8 also got into a loop between `FormValidator#handleFormSubmit` and `FormValidator#checkForm`, which submitted the form again, thereby triggering `handleFormSubmit` again. This caused a stack overflow. I've put in a flag so `handleFormSubmit` returns true if the form has already been submitted.

Hope this is helpful. Let me know if you need anything tweaked.
Caden
